### PR TITLE
add func WithTransactionID()

### DIFF
--- a/digilog.go
+++ b/digilog.go
@@ -51,6 +51,11 @@ type Log struct {
 	caller bool
 }
 
+func (l *Log) WithTransactionID(id string) *Log {
+	l.AddTag("transaction_id", id)
+	return l
+}
+
 // SetOutput changes the output buffer per log
 func (l *Log) SetOutput(o *BuffOut) {
 	l.out = o

--- a/digilog.go
+++ b/digilog.go
@@ -51,6 +51,7 @@ type Log struct {
 	caller bool
 }
 
+// WithTransactionID adds a "transaction_id" tag to the Log
 func (l *Log) WithTransactionID(id string) *Log {
 	l.AddTag("transaction_id", id)
 	return l

--- a/digilog_test.go
+++ b/digilog_test.go
@@ -231,3 +231,15 @@ func TestLogLevel(t *testing.T) {
 	l.Debugf("test_event", "salutation='%s'", "hello empty void")
 	assert.Empty(testBuff.String())
 }
+
+func TestLog_WithTransactionID(t *testing.T) {
+	testBuff.Reset()
+	assert := assert.New(t)
+
+	LogLevel = "INFO"
+	transactionID := "veryUniqueTransactionID"
+	l := New().WithTransactionID(transactionID)
+	l.SetOutput(Out)
+	l.Info("test_event")
+	assert.True(strings.Contains(testBuff.String(), transactionID))
+}


### PR DESCRIPTION
New func allows you to easily instantiate a new logger with a `transaction_id` tag.

Usage:
```go
l := digilog.New().WithTransactionID("transactionID")
```

The _transactionID_ value will be printed in each log statement.