### PR TITLE
added a default error format so it doesn't have to be defined every time

### DIFF
--- a/digilog.go
+++ b/digilog.go
@@ -130,6 +130,13 @@ func (l *Log) Warnf(event string, args ...interface{}) {
 
 // Error shortcut for log function
 func (l *Log) Error(event string, args ...interface{}) {
+	if len(args) == 1 {
+		val, ok := args[0].(error)
+		if ok {
+			l.Errorf(event, "error=%q", val)
+			return
+		}
+	}
 	message := fmt.Sprint(args...)
 	l.Errorf(event, message)
 }


### PR DESCRIPTION
we're having several code smells in sonar come up because we have the string err=%q or error=%q being used several times. I think it makes sense to provide a default output if we just pass in logger.Error("event", err)

This helps with having err vs error being more consistent and will prevent any typos in the error message that we may miss otherwise.

I'm not sure if we would prefer to change the type of logger.Error or just add logic internally so I have added in a way that keeps the same type definition. I'm definitely open to suggestions if there is a better way to be solving this